### PR TITLE
refactor: make light theme default map theme and order themes lightest to darkest

### DIFF
--- a/src/Map/Map.tsx
+++ b/src/Map/Map.tsx
@@ -28,18 +28,6 @@ const Map = (props: MapProps): JSX.Element => {
     const availableTileSets: TileSet[] = [
         {
             id: 1,
-            value: 'carto-dark',
-            name: 'Dark',
-            attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
-            url: 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png',
-            planeIcon: PlaneCyan,
-            planeIconHighlight: PlaneBlue,
-            departureIcon: DepartureWhite,
-            arrivalIcon: ArrivalWhite,
-            previewImageUrl: CartoDarkPreview,
-        },
-        {
-            id: 2,
             value: 'carto-light',
             name: 'Light',
             attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
@@ -51,7 +39,7 @@ const Map = (props: MapProps): JSX.Element => {
             previewImageUrl: CartoLightPreview,
         },
         {
-            id: 3,
+            id: 2,
             value: 'osm',
             name: 'Open Street Map',
             attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
@@ -61,7 +49,19 @@ const Map = (props: MapProps): JSX.Element => {
             departureIcon: DepartureGray,
             arrivalIcon: ArrivalGray,
             previewImageUrl: OsmPreview,
-        }
+        },
+        {
+            id: 3,
+            value: 'carto-dark',
+            name: 'Dark',
+            attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
+            url: 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png',
+            planeIcon: PlaneCyan,
+            planeIconHighlight: PlaneBlue,
+            departureIcon: DepartureWhite,
+            arrivalIcon: ArrivalWhite,
+            previewImageUrl: CartoDarkPreview,
+        },
     ];
 
     const [selectedTile, setSelectedTile] = useLocalStorage<TileSet>(


### PR DESCRIPTION
Re-orders the map themes from lightest to darkest. The map on the website will no longer default to the dark theme. 

![image](https://user-images.githubusercontent.com/30361843/108941673-1ac14380-761b-11eb-82ed-ef2f9de343a0.png)
